### PR TITLE
use X509CertRef to get the namespace of the cert

### DIFF
--- a/pkg/api/v1/atlasproject_types.go
+++ b/pkg/api/v1/atlasproject_types.go
@@ -156,8 +156,12 @@ func (p *AtlasProject) UpdateStatus(conditions []status.Condition, options ...st
 }
 
 func (p *AtlasProject) X509SecretObjectKey() *client.ObjectKey {
+	namespace := p.Spec.X509CertRef.Namespace
+	if namespace == "" {
+		namespace = p.Namespace
+	}
 	if p.Spec.X509CertRef != nil {
-		key := kube.ObjectKey(p.Namespace, p.Spec.X509CertRef.Name)
+		key := kube.ObjectKey(namespace, p.Spec.X509CertRef.Name)
 		return &key
 	}
 	return nil


### PR DESCRIPTION
X509CertRef is a ResourceRefNamespaced, which means it contains a name and a namespace. The name is only used to get the object while the namespace is discarded, This PR uses the namespace defined here to get the object while falling back to the project namespace to maintain backward compatibility.

This can break projects for people configuring the namespace differently that what's intended. It will only break if the configuration is initially wrong.
